### PR TITLE
refactor(junit): upgrade junit 4 to 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,11 @@ dependencies {
     implementation 'org.processing:core:3.3.7'
 
     // Use JUnit test framework
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+
+    // Use Hamcrest matchers
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 application {
@@ -42,6 +46,7 @@ application {
 }
 
 test {
+  useJUnitPlatform()
   finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/brick/breaker/entities/Ball.java
+++ b/src/main/java/brick/breaker/entities/Ball.java
@@ -95,12 +95,12 @@ public class Ball extends Shape<Ball> implements Collision, Movement {
   @Override
   public void update() {
     if (this.position.x - this.radius < minGameSize.x
-      || this.position.x + this.radius > maxGameSize.x) {
+        || this.position.x + this.radius > maxGameSize.x) {
       this.direction.x *= -1;
     }
 
     if (this.position.y - this.radius < minGameSize.y
-      || this.position.y + this.radius > maxGameSize.y) {
+        || this.position.y + this.radius > maxGameSize.y) {
       this.direction.y *= -1;
     }
 

--- a/src/main/java/brick/breaker/entities/Paddle.java
+++ b/src/main/java/brick/breaker/entities/Paddle.java
@@ -49,13 +49,13 @@ public class Paddle extends Box<Paddle> implements Movement {
 
   @Override
   public void setTargetPosition(PVector position) {
-    float xPosition = position.x;
-    if (xPosition < this.minGameSize.x + this.halfSize.x) {
-      xPosition = this.minGameSize.x + this.halfSize.x;
-    } else if (xPosition > this.maxGameSize.x - this.halfSize.x) {
-      xPosition = this.maxGameSize.x - this.halfSize.x;
+    float newPositionX = position.x;
+    if (newPositionX < this.minGameSize.x + this.halfSize.x) {
+      newPositionX = this.minGameSize.x + this.halfSize.x;
+    } else if (newPositionX > this.maxGameSize.x - this.halfSize.x) {
+      newPositionX = this.maxGameSize.x - this.halfSize.x;
     }
-    this.targetPosition.set(xPosition, this.position.y);
+    this.targetPosition.set(newPositionX, this.position.y);
   }
 
   @Override

--- a/src/main/java/brick/breaker/managers/GameManager.java
+++ b/src/main/java/brick/breaker/managers/GameManager.java
@@ -29,14 +29,13 @@ public class GameManager {
 
     PVector initialBallPosition = new PVector(sketch.width / 2, sketch.height / 2);
     PVector initialBallTarget = new PVector(sketch.width / 2, sketch.height);
-    PVector initialPaddlePosition = new PVector(sketch.width / 2, 5 * sketch.height / 6);
-
     PVector ballSize = new PVector(BALL_RADIUS, BALL_RADIUS);
-    PVector paddleSize = new PVector(PADDLE_WIDTH, PADDLE_HEIGHT);
-
     ball = new Ball().setPosition(initialBallPosition).setSize(ballSize);
     ball.setTargetPosition(initialBallTarget);
     ball.setMovementBoundary(minSize, maxSize);
+
+    PVector initialPaddlePosition = new PVector(sketch.width / 2, 5 * sketch.height / 6);
+    PVector paddleSize = new PVector(PADDLE_WIDTH, PADDLE_HEIGHT);
     paddle = new Paddle().setPosition(initialPaddlePosition).setSize(paddleSize);
     paddle.setMovementBoundary(minSize, maxSize);
   }

--- a/src/test/java/brick/breaker/AppTest.java
+++ b/src/test/java/brick/breaker/AppTest.java
@@ -4,9 +4,9 @@
 
 package brick.breaker;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import processing.core.PApplet;
 
 public class AppTest {

--- a/src/test/java/brick/breaker/entities/BallTest.java
+++ b/src/test/java/brick/breaker/entities/BallTest.java
@@ -1,12 +1,12 @@
 package brick.breaker.entities;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import processing.core.PVector;
 
 public class BallTest {
@@ -55,7 +55,7 @@ public class BallTest {
     ball.setMaxSpeed(speed);
     ball.setTargetPosition(newPosition);
     ball.update();
-    assertThat(ball.getPosition().array(), IsNot.not(IsEqual.equalTo(newPosition.array())));
+    assertThat(ball.getPosition().array(), not(is(newPosition.array())));
   }
 
   @Test
@@ -66,14 +66,14 @@ public class BallTest {
     for (int i = 0; i < 5; i++) {
       ball.update();
     }
-    assertTrue("Ball X position should be greater than min bounds x",
-        ball.getPosition().x > minBoundary.x);
-    assertTrue("Ball X position should be less than max bounds x",
-        ball.getPosition().x < maxBoundary.x);
-    assertTrue("Ball Y position should be greater than min bounds y",
-        ball.getPosition().x > minBoundary.y);
-    assertTrue("Ball Y position should be less than max bounds y",
-        ball.getPosition().x < maxBoundary.y);
+    assertTrue(ball.getPosition().x > minBoundary.x,
+        "Ball X position should be greater than min bounds x");
+    assertTrue(ball.getPosition().x < maxBoundary.x,
+        "Ball X position should be less than max bounds x");
+    assertTrue(ball.getPosition().x > minBoundary.y,
+        "Ball Y position should be greater than min bounds y");
+    assertTrue(ball.getPosition().x < maxBoundary.y,
+        "Ball Y position should be less than max bounds y");
   }
 }
 

--- a/src/test/java/brick/breaker/entities/BallTest.java
+++ b/src/test/java/brick/breaker/entities/BallTest.java
@@ -6,35 +6,44 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import processing.core.PVector;
 
 public class BallTest {
 
-  private static Ball ball = new Ball();
-  private static PVector ballPosition = new PVector(26, 26);
-  private static PVector ballSize = new PVector(50, 50);
-  private static PVector minBoundary = new PVector(0, 0);
-  private static PVector maxBoundary = new PVector(500, 500);
+  private Ball ball;
+  private PVector ballPosition;
+  private PVector ballSize;
+  private PVector minBoundary;
+  private PVector maxBoundary;
+
+  @BeforeEach
+  public void initialize() {
+    ballPosition = new PVector(26, 26);
+    ballSize = new PVector(50, 50);
+    minBoundary = new PVector(0, 0);
+    maxBoundary = new PVector(500, 500);
+    ball = new Ball();
+    ball.setPosition(ballPosition);
+    ball.setSize(ballSize);
+    ball.setMovementBoundary(minBoundary, maxBoundary);
+  }
 
   @Test
   public void testBallSetSize() {
-    ball.setSize(ballSize);
     assertEquals(ballSize.x, ball.getSize().x, 0.1);
     assertEquals(ballSize.y, ball.getSize().y, 0.1);
   }
 
   @Test
   public void testBallSetStartingLocation() {
-    ball.setPosition(ballPosition);
     assertEquals(ballPosition.x, ball.getPosition().x, 0.1);
     assertEquals(ballPosition.y, ball.getPosition().y, 0.1);
   }
 
   @Test
   public void testBallDetectCollisionTrue() {
-    ball.setPosition(ballPosition).setSize(ballSize);
-
     // collision should happen at brick's bottom left corner
     // and balls' top right vertex (approx (113, 121))
     PVector brickSize = new PVector(100, 50);
@@ -51,7 +60,6 @@ public class BallTest {
   public void testBallMovement() {
     PVector newPosition = new PVector(0, 0);
     float speed = 60;
-    ball.setMovementBoundary(minBoundary, maxBoundary);
     ball.setMaxSpeed(speed);
     ball.setTargetPosition(newPosition);
     ball.update();
@@ -61,7 +69,6 @@ public class BallTest {
   @Test
   public void testBallOutOfBounds() {
     PVector newPosition = new PVector(0, 0);
-    ball.setMovementBoundary(minBoundary, maxBoundary);
     ball.setTargetPosition(newPosition);
     for (int i = 0; i < 5; i++) {
       ball.update();

--- a/src/test/java/brick/breaker/entities/BallTest.java
+++ b/src/test/java/brick/breaker/entities/BallTest.java
@@ -18,6 +18,9 @@ public class BallTest {
   private PVector minBoundary;
   private PVector maxBoundary;
 
+  /**
+   * Initialize testable objects.
+   */
   @BeforeEach
   public void initialize() {
     ballPosition = new PVector(26, 26);

--- a/src/test/java/brick/breaker/entities/BrickTest.java
+++ b/src/test/java/brick/breaker/entities/BrickTest.java
@@ -1,9 +1,9 @@
 package brick.breaker.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BrickTest {
 

--- a/src/test/java/brick/breaker/entities/BrickTest.java
+++ b/src/test/java/brick/breaker/entities/BrickTest.java
@@ -1,20 +1,30 @@
 package brick.breaker.entities;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class BrickTest {
+
+  private Brick brick;
+
+  /**
+   * Initialize object values.
+   */
+  @BeforeEach
+  public void initialize() {
+    brick = new Brick();
+  }
 
   @Test
   public void testSetHealthError() {
     int illegalValue = -5;
 
-    assertThrows(IllegalArgumentException.class, () -> {
-      Brick brick = new Brick();
-      brick.setMaxHealth(illegalValue);
-    });
+    assertThrows(IllegalArgumentException.class, () -> brick.setMaxHealth(illegalValue));
   }
 
   /**
@@ -24,17 +34,21 @@ public class BrickTest {
   public void testBrickHealth() {
     int initialHealth = 10;
 
-    Brick brick = new Brick();
     brick.setMaxHealth(initialHealth);
-    assertEquals(initialHealth, brick.getHealth());
+    assertThat(String.format("Brick health has been set to %d", initialHealth),
+        brick.getHealth(), is(equalTo(initialHealth)));
 
     int damageOne = 5;
+    int expectedHealthAfterDamageOne = 5;
     brick.damage(damageOne);
-    assertEquals(initialHealth - damageOne, brick.getHealth());
+    assertThat(
+        String.format("Brick has been damaged by %d points, total health should be %d",
+            damageOne, expectedHealthAfterDamageOne),
+        brick.getHealth(), is(equalTo(initialHealth - damageOne)));
 
     int damageTwo = 20;
     brick.damage(damageTwo);
-    assertEquals(0, brick.getHealth());
+    assertThat("Brick health should not fall below 0", brick.getHealth(), is(equalTo(0)));
   }
 }
 

--- a/src/test/java/brick/breaker/entities/PaddleTest.java
+++ b/src/test/java/brick/breaker/entities/PaddleTest.java
@@ -1,54 +1,58 @@
 package brick.breaker.entities;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsNot;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import processing.core.PVector;
 
 public class PaddleTest {
-  private static final PVector initialPosition = new PVector(50, 450);
-  private static final PVector minBoundary = new PVector(0, 0);
-  private static final PVector maxBoundary = new PVector(500, 500);
-  private static final PVector paddleSize = new PVector(100, 50);
+  private Paddle paddle;
+  private PVector initialPosition;
+  private PVector newPosition;
 
-  @Test
-  public void testPaddleMovement() {
-    PVector newPosition = new PVector(600, 0);
-    float maxSpeed = 5;
-
-    Paddle paddle = new Paddle();
+  /**
+   * Initialize required properties of {@link Paddle}.
+   */
+  @BeforeEach
+  public void initialize() {
+    paddle = new Paddle();
+    initialPosition = new PVector(50, 450);
+    PVector minBoundary = new PVector(0, 0);
+    PVector maxBoundary = new PVector(500, 500);
+    PVector paddleSize = new PVector(100, 50);
+    newPosition = new PVector(600, 0);
     paddle.setMovementBoundary(minBoundary, maxBoundary);
     paddle.setSize(paddleSize);
     paddle.setPosition(initialPosition);
-    paddle.setMaxSpeed(maxSpeed);
     paddle.setTargetPosition(newPosition);
+  }
+
+  @Test
+  public void testPaddleMovement() {
+    float maxSpeed = 5;
+
+    paddle.setMaxSpeed(maxSpeed);
     paddle.update();
 
-    assertThat(paddle.getPosition().array(), IsNot.not(IsEqual.equalTo(initialPosition.array())));
+    assertThat(paddle.getPosition().array(), is(not(initialPosition.array())));
   }
 
   @Test
   public void testSetSpeedThrowsError() {
     float incorrectArgument = -5;
 
-    assertThrows(IllegalArgumentException.class, () -> {
-      Paddle paddle = new Paddle();
-      paddle.setMaxSpeed(incorrectArgument);
-    });
+    assertThrows(IllegalArgumentException.class, () -> paddle.setMaxSpeed(incorrectArgument));
   }
 
   @Test
   public void testSetTargetPositionOutOfBounds() {
-    PVector newPosition = new PVector(-50, initialPosition.y);
-    Paddle paddle = new Paddle();
-    paddle.setMovementBoundary(minBoundary, maxBoundary);
-    paddle.setPosition(initialPosition);
-    paddle.setSize(paddleSize);
+    newPosition.set(-50, initialPosition.y);
     paddle.setTargetPosition(newPosition);
     paddle.update();
-    assertThat(paddle.getPosition().array(), IsEqual.equalTo(initialPosition.array()));
+    assertThat(paddle.getPosition().array(), is(initialPosition.array()));
   }
 }

--- a/src/test/java/brick/breaker/entities/PaddleTest.java
+++ b/src/test/java/brick/breaker/entities/PaddleTest.java
@@ -1,11 +1,11 @@
 package brick.breaker.entities;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.IsNot;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import processing.core.PVector;
 
 public class PaddleTest {


### PR DESCRIPTION
Upgrade from Gradle defaults of JUnit v4 to v5 because it's the current release and it's easier to upgrade before creating more specific tests.
Import Hamcrest package for better matcher assertions compared to built-in JUnit assertions.
Refactor tests using before-each functions to instantiate new test objects which ensures immutability and decreases hard-dependency across test cases.
Closes #17 
